### PR TITLE
Updated with appropriate version matching

### DIFF
--- a/cudnn.md
+++ b/cudnn.md
@@ -43,7 +43,19 @@ The actual library for cuDNN is not bundled, so be sure to download and install 
 
 * [NVIDIA cuDNN](https://developer.nvidia.com/cudnn)
 
-Note that only cuDNN 6.0 is supported. To install, simply extract the library to a directory found in the system path used by native libraries. The easiest way is to place it alongside other libraries from CUDA in the default directory (`/usr/local/cuda/lib64/` on Linux, `/usr/local/cuda/lib/` on Mac OS X, and `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v7.5\bin\` or `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v8.0\bin\` on Windows).
+Note there are multiple combinations of cuDNN and CUDA supported. At this time the following combinations are supported by Deeplearning4j:
+<table style="width:60%">
+	<tr>
+		<th>CUDA Version</th>
+		<th>cuDNN Version</th>
+	</tr>
+	<tr><td>7.5</td><td>6.0</td></tr>
+	<tr><td>8.0</td><td>6.0</td></tr>
+	<tr><td>9.x</td><td>7.x</td></tr>
+</table>
+
+ 
+ To install, simply extract the library to a directory found in the system path used by native libraries. The easiest way is to place it alongside other libraries from CUDA in the default directory (`/usr/local/cuda/lib64/` on Linux, `/usr/local/cuda/lib/` on Mac OS X, and `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v7.5\bin\` or `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v8.0\bin\` on Windows).
 
 Also note that, by default, Deeplearning4j will use the fastest algorithms available according to cuDNN, but memory usage may be excessive, causing strange launch errors. When this happens, try to reduce memory usage by using the [`NO_WORKSPACE` mode settable via the network configuration](https://deeplearning4j.org/doc/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.Builder.html#cudnnAlgoMode-org.deeplearning4j.nn.conf.layers.ConvolutionLayer.AlgoMode-), instead of the default of `ConvolutionLayer.AlgoMode.PREFER_FASTEST`, for example:
 


### PR DESCRIPTION
See https://github.com/deeplearning4j/deeplearning4j/issues/4757

Updating cuDNN with compatibility matrix. 

